### PR TITLE
Update Tiltfile

### DIFF
--- a/live-update/Tiltfile
+++ b/live-update/Tiltfile
@@ -4,7 +4,7 @@ NAMESPACE = os.getenv("NAMESPACE", default='default')
 
 k8s_custom_deploy(
     'my-project',
-    apply_cmd="tanzu apps workload apply -f config/workload.yaml --live-update" +
+    apply_cmd="tanzu apps workload apply -f config/workload.yaml --debug --live-update" +
               " --local-path " + LOCAL_PATH +
               " --source-image " + SOURCE_IMAGE +
               " --namespace " + NAMESPACE +


### PR DESCRIPTION
Enable debug by default

This will not activate the debug functionality, but simply enable it such that we don't have to do another image build when/if the user activates tanzu debug