### PR TITLE
chore: update tiltfile to consume new env var

### DIFF
--- a/live-update/Tiltfile
+++ b/live-update/Tiltfile
@@ -9,7 +9,7 @@ k8s_custom_deploy(
               " --local-path " + LOCAL_PATH +
               " --source-image " + SOURCE_IMAGE +
               " --namespace " + NAMESPACE +
-              " --yes" +
+              " --yes " +
               OUTPUT_TO_NULL_COMMAND +
               " && kubectl get workload my-project --namespace " + NAMESPACE + " -o yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",

--- a/live-update/Tiltfile
+++ b/live-update/Tiltfile
@@ -1,6 +1,7 @@
 SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='dev.local/my-project-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+OUTPUT_TO_NULL_COMMAND = os.getenv("OUTPUT_TO_NULL_COMMAND", default=' > /dev/null ')
 
 k8s_custom_deploy(
     'my-project',
@@ -8,7 +9,8 @@ k8s_custom_deploy(
               " --local-path " + LOCAL_PATH +
               " --source-image " + SOURCE_IMAGE +
               " --namespace " + NAMESPACE +
-              " --yes >/dev/null" +
+              " --yes" +
+              OUTPUT_TO_NULL_COMMAND +
               " && kubectl get workload my-project --namespace " + NAMESPACE + " -o yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",
     deps=['pom.xml', './target/classes'],


### PR DESCRIPTION
New env var will be set by IDE plugins to an OS-specific value. e.g.` > /dev/null ` on *nix systems or ` > $null ` on Windows